### PR TITLE
Feature/http transport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>https://www.khronos.org/files/collada_schema_1_5</url>
+							<url>http://www.khronos.org/files/collada_schema_1_5</url>
 							<unpack>false</unpack>
 							<outputDirectory>${xsdDirectory}</outputDirectory>
 							<!-- xjc below depends on the file extension: -->


### PR DESCRIPTION
This feature downgrades the download of the Collada xsd to http.
Khronos seems to have followed comon practice of tightening up their TLS security.
However, this means some Java installations may fail to download the xsd.
Since we're ensuring the download with our own MD5 sum and the xsd is not really sensitive information, I think in this case it's OK to drop secure transport.
